### PR TITLE
Accept compute config parameters

### DIFF
--- a/scripts/enqueue-qupath-measurement.py
+++ b/scripts/enqueue-qupath-measurement.py
@@ -19,7 +19,7 @@ from deepcell_imaging.gcp_batch_jobs.quantify import (
     make_quantify_job,
 )
 from deepcell_imaging.gcp_batch_jobs.types import EnqueueQuantifyArgs
-from deepcell_imaging.utils.cmdline import get_task_arguments
+from deepcell_imaging.utils.cmdline import get_task_arguments, parse_compute_config
 
 
 def main():
@@ -52,6 +52,7 @@ def main():
         args=args,
         networking_interface=env_config.networking_interface,
         service_account=env_config.service_account,
+        compute_config=parse_compute_config(args.compute_config),
     )
 
     job_json_file = tempfile.NamedTemporaryFile()

--- a/scripts/enqueue-qupath-measurement.py
+++ b/scripts/enqueue-qupath-measurement.py
@@ -18,7 +18,7 @@ import logging
 from deepcell_imaging.gcp_batch_jobs.quantify import (
     make_quantify_job,
 )
-from deepcell_imaging.gcp_batch_jobs.types import QuantifyArgs
+from deepcell_imaging.gcp_batch_jobs.types import EnqueueQuantifyArgs
 from deepcell_imaging.utils.cmdline import get_task_arguments
 
 
@@ -36,7 +36,9 @@ def main():
         logger.info(f"Skipping task {task_index}; we only run the first task.")
         return
 
-    args, env_config = get_task_arguments("launch_qupath_measurement", QuantifyArgs)
+    args, env_config = get_task_arguments(
+        "launch_qupath_measurement", EnqueueQuantifyArgs
+    )
 
     if not env_config:
         raise ValueError("Environment configuration is required")

--- a/scripts/segment-and-measure.py
+++ b/scripts/segment-and-measure.py
@@ -25,7 +25,7 @@ from deepcell_imaging.gcp_batch_jobs.segment import (
     build_segment_job_tasks,
     upload_tasks,
 )
-from deepcell_imaging.gcp_batch_jobs.types import QuantifyArgs, EnvironmentConfig
+from deepcell_imaging.gcp_batch_jobs.types import EnqueueQuantifyArgs, EnvironmentConfig
 from deepcell_imaging.utils.cmdline import add_dataset_parameters, get_dataset_paths
 from deepcell_imaging.utils.storage import get_blob_filenames
 
@@ -113,7 +113,7 @@ def main():
     append_quantify_enqueuer(
         job,
         env_config.segment_container_image,
-        QuantifyArgs(
+        EnqueueQuantifyArgs(
             images_path=dataset_paths["image_root"],
             segmasks_path=dataset_paths["masks_output_root"],
             project_path=dataset_paths["project_root"],

--- a/scripts/segment-and-measure.py
+++ b/scripts/segment-and-measure.py
@@ -19,7 +19,7 @@ from google.cloud import storage
 
 import deepcell_imaging.gcp_logging
 from deepcell_imaging.gcp_batch_jobs import submit_job
-from deepcell_imaging.gcp_batch_jobs.quantify import append_quantify_task
+from deepcell_imaging.gcp_batch_jobs.quantify import append_quantify_enqueuer
 from deepcell_imaging.gcp_batch_jobs.segment import (
     make_segmentation_tasks,
     build_segment_job_tasks,
@@ -104,12 +104,13 @@ def main():
         working_directory=working_directory,
         bigquery_benchmarking_table=env_config.bigquery_benchmarking_table,
         networking_interface=env_config.networking_interface,
+        compute_config=segment_compute_config,
         service_account=env_config.service_account,
     )
 
     # Note that we use the SEGMENT container here, not quantify,
     # because we launch the quantify job FROM the segment job.
-    append_quantify_task(
+    append_quantify_enqueuer(
         job,
         env_config.segment_container_image,
         QuantifyArgs(

--- a/scripts/segment.py
+++ b/scripts/segment.py
@@ -25,7 +25,11 @@ from deepcell_imaging.gcp_batch_jobs.segment import (
     upload_tasks,
 )
 from deepcell_imaging.gcp_batch_jobs.types import EnvironmentConfig
-from deepcell_imaging.utils.cmdline import add_dataset_parameters, get_dataset_paths
+from deepcell_imaging.utils.cmdline import (
+    add_dataset_parameters,
+    get_dataset_paths,
+    parse_compute_config,
+)
 from deepcell_imaging.utils.storage import get_blob_filenames
 
 
@@ -48,10 +52,17 @@ def main():
         type=str,
         required=True,
     )
+    parser.add_argument(
+        "--compute_config",
+        help="Compute config for segmentation",
+        type=str,
+        default="n1-standard-8:SPOT+nvidia-tesla-t4:1",
+    )
 
     add_dataset_parameters(parser, require_measurement_parameters=False)
 
     args = parser.parse_args()
+    compute_config = parse_compute_config(args.compute_config)
 
     dataset_paths = get_dataset_paths(args)
 
@@ -96,6 +107,7 @@ def main():
     job = build_segment_job_tasks(
         region=env_config.region,
         container_image=env_config.segment_container_image,
+        compute_config=compute_config,
         model_path=env_config.segment_model_path,
         model_hash=env_config.segment_model_hash,
         tasks=image_segmentation_tasks,

--- a/src/deepcell_imaging/gcp_batch_jobs/quantify.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/quantify.py
@@ -62,7 +62,7 @@ BASE_QUANTIFY_JOB_TEMPLATE = """
 """
 
 
-def append_quantify_task(
+def append_quantify_enqueuer(
     job: dict,
     container_image: str,
     args: QuantifyArgs,

--- a/src/deepcell_imaging/gcp_batch_jobs/quantify.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/quantify.py
@@ -10,7 +10,7 @@ from deepcell_imaging.gcp_batch_jobs import (
     add_service_account,
 )
 from deepcell_imaging.gcp_batch_jobs.types import (
-    QuantifyArgs,
+    EnqueueQuantifyArgs,
     ServiceAccountConfig,
     NetworkInterfaceConfig,
     ComputeConfig,
@@ -65,7 +65,7 @@ BASE_QUANTIFY_JOB_TEMPLATE = """
 def append_quantify_enqueuer(
     job: dict,
     container_image: str,
-    args: QuantifyArgs,
+    args: EnqueueQuantifyArgs,
     env_config_uri: str = "",
 ):
     cmd_args = [
@@ -90,7 +90,7 @@ def append_quantify_enqueuer(
 def make_quantify_job(
     region: str,
     container_image: str,
-    args: QuantifyArgs,
+    args: EnqueueQuantifyArgs,
     networking_interface: NetworkInterfaceConfig = None,
     compute_config: ComputeConfig = None,
     service_account: ServiceAccountConfig = None,

--- a/src/deepcell_imaging/gcp_batch_jobs/quantify.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/quantify.py
@@ -13,6 +13,7 @@ from deepcell_imaging.gcp_batch_jobs.types import (
     QuantifyArgs,
     ServiceAccountConfig,
     NetworkInterfaceConfig,
+    ComputeConfig,
 )
 
 # Note: Need to escape the curly braces in the JSON template
@@ -91,6 +92,7 @@ def make_quantify_job(
     container_image: str,
     args: QuantifyArgs,
     networking_interface: NetworkInterfaceConfig = None,
+    compute_config: ComputeConfig = None,
     service_account: ServiceAccountConfig = None,
     config: dict = None,
 ) -> dict:
@@ -107,12 +109,13 @@ def make_quantify_job(
     print(json_str)
     job = json.loads(json_str)
 
-    apply_allocation_policy(
-        job,
-        region,
-        "n1-standard-8",
-        "SPOT",
-    )
+    if not compute_config:
+        compute_config = ComputeConfig(
+            machine_type="n1-standard-8",
+            provisioning_model="SPOT",
+        )
+
+    apply_allocation_policy(job, region, compute_config)
     apply_cloud_logs_policy(job)
 
     # We know this is (probably) way too much– but we don't have accurate

--- a/src/deepcell_imaging/gcp_batch_jobs/segment.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/segment.py
@@ -21,6 +21,7 @@ from deepcell_imaging.gcp_batch_jobs.types import (
     VisualizeArgs,
     SegmentationTask,
     NetworkInterfaceConfig,
+    ComputeConfig,
     ServiceAccountConfig,
 )
 from deepcell_imaging.utils.numpy import npz_headers
@@ -231,6 +232,7 @@ def build_segment_job_tasks(
     working_directory: str,
     bigquery_benchmarking_table: Optional[str] = None,
     networking_interface: NetworkInterfaceConfig = None,
+    compute_config: ComputeConfig = None,
     service_account: ServiceAccountConfig = None,
     config: dict = None,
 ) -> dict:
@@ -279,13 +281,18 @@ def build_segment_job_tasks(
         create_segmenting_runnable(container_image, "visualize", phase_task_defs),
     ]
 
+    if not compute_config:
+        compute_config = ComputeConfig(
+            machine_type="n1-standard-8",
+            provisioning_model="SPOT",
+            accelerator_count=1,
+            accelerator_type="nvidia-tesla-t4",
+        )
+
     apply_allocation_policy(
         job,
         region,
-        "n1-standard-8",
-        "SPOT",
-        gpu_type="nvidia-tesla-t4",
-        gpu_count=1,
+        compute_config,
     )
     apply_cloud_logs_policy(job)
 

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -256,7 +256,7 @@ class GatherBenchmarkArgs(BaseModel):
     )
 
 
-class QuantifyArgs(BaseModel):
+class EnqueueQuantifyArgs(BaseModel):
     images_path: str = Field(
         title="Images Path",
         description="Path to the directory containing the images for QuPath.",

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -23,6 +23,29 @@ class NetworkInterfaceConfig(BaseModel):
     )
 
 
+class ComputeConfig(BaseModel):
+    machine_type: str = Field(
+        default="n1-standard-8",
+        title="Machine Type",
+        description="The machine type to use for the job.",
+    )
+    provisioning_model: str = Field(
+        default="SPOT",
+        title="Provisioning Model",
+        description="The provisioning model to use for the job.",
+    )
+    accelerator_count: int = Field(
+        default=0,
+        title="Accelerator Count",
+        description="The number of accelerators to use for the job.",
+    )
+    accelerator_type: str = Field(
+        default="",
+        title="Accelerator Type",
+        description="The type of accelerator to use for the job.",
+    )
+
+
 class ServiceAccountConfig(BaseModel):
     email: str = Field(
         default="",

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -278,3 +278,7 @@ class EnqueueQuantifyArgs(BaseModel):
         title="Image Filter",
         description="Filter for which image names to process. Default/blank: no filter.",
     )
+    compute_config: str = Field(
+        title="Compute Config",
+        description="The compute config (machine type + accelerator) to use for the job.",
+    )

--- a/tests/deepcell_imaging/gcp_batch_jobs/quantify_test.py
+++ b/tests/deepcell_imaging/gcp_batch_jobs/quantify_test.py
@@ -1,7 +1,7 @@
 from unittest.mock import ANY, patch
 
 from deepcell_imaging.gcp_batch_jobs.quantify import make_quantify_job
-from deepcell_imaging.gcp_batch_jobs.types import QuantifyArgs
+from deepcell_imaging.gcp_batch_jobs.types import EnqueueQuantifyArgs
 
 
 @patch("smart_open.open")
@@ -9,7 +9,7 @@ def test_make_quantify_job(_patched_open):
     job = make_quantify_job(
         region="a-region",
         container_image="an-image",
-        args=QuantifyArgs(
+        args=EnqueueQuantifyArgs(
             images_path="/images/path",
             segmasks_path="/segmasks/path",
             project_path="/project/path",

--- a/tests/deepcell_imaging/utils/cmdline_test.py
+++ b/tests/deepcell_imaging/utils/cmdline_test.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, patch
 
 from pydantic import BaseModel, Field
 
-from deepcell_imaging.utils.cmdline import get_task_arguments
+from deepcell_imaging.utils.cmdline import get_task_arguments, parse_compute_config
 
 
 class ArgsForTest(BaseModel):
@@ -64,3 +64,53 @@ def test_tasks_uri():
     assert result.project_path == "gs://root/project"
     assert result.reports_path == "/root/reports"
     assert result.image_filter == ""
+
+
+def test_parse_compute_config():
+    compute_config = parse_compute_config("n123-standard-456:ABC+fast-gpu:321")
+    assert compute_config.machine_type == "n123-standard-456"
+    assert compute_config.provisioning_model == "ABC"
+    assert compute_config.accelerator_type == "fast-gpu"
+    assert compute_config.accelerator_count == 321
+
+    compute_config = parse_compute_config("")
+    assert compute_config.machine_type == "n1-standard-8"
+    assert compute_config.provisioning_model == "SPOT"
+    assert compute_config.accelerator_type == "nvidia-tesla-t4"
+    assert compute_config.accelerator_count == 1
+
+    compute_config = parse_compute_config("a-b-c")
+    assert compute_config.machine_type == "a-b-c"
+    assert compute_config.provisioning_model == "SPOT"
+    assert compute_config.accelerator_type == "nvidia-tesla-t4"
+    assert compute_config.accelerator_count == 1
+
+    compute_config = parse_compute_config(":SPOT")
+    assert compute_config.machine_type == "n1-standard-8"
+    assert compute_config.provisioning_model == "SPOT"
+    assert compute_config.accelerator_type == "nvidia-tesla-t4"
+    assert compute_config.accelerator_count == 1
+
+    compute_config = parse_compute_config(":SPOT+:7")
+    assert compute_config.machine_type == "n1-standard-8"
+    assert compute_config.provisioning_model == "SPOT"
+    assert compute_config.accelerator_type == "nvidia-tesla-t4"
+    assert compute_config.accelerator_count == 7
+
+    compute_config = parse_compute_config("+gpu:3")
+    assert compute_config.machine_type == "n1-standard-8"
+    assert compute_config.provisioning_model == "SPOT"
+    assert compute_config.accelerator_type == "gpu"
+    assert compute_config.accelerator_count == 3
+
+    compute_config = parse_compute_config("+gpu")
+    assert compute_config.machine_type == "n1-standard-8"
+    assert compute_config.provisioning_model == "SPOT"
+    assert compute_config.accelerator_type == "gpu"
+    assert compute_config.accelerator_count == 1
+
+    compute_config = parse_compute_config("machine+gpu")
+    assert compute_config.machine_type == "machine"
+    assert compute_config.provisioning_model == "SPOT"
+    assert compute_config.accelerator_type == "gpu"
+    assert compute_config.accelerator_count == 1


### PR DESCRIPTION
The compute allocation for jobs needs to change with input size.

For now, let the user control the compute config with command-line arguments.

Eventually, we may get smarter about sizing the machine based on pixels etc…

Fixes #371 