### PR TITLE
Filter out blobs with empty basenames

### DIFF
--- a/src/deepcell_imaging/utils/storage.py
+++ b/src/deepcell_imaging/utils/storage.py
@@ -19,10 +19,14 @@ def get_blob_filenames(uri_prefix, client=None):
 
     root_blob = Blob.from_string(uri_prefix, client=client)
     bucket = client.bucket(root_blob.bucket.name)
+
+    # Filter out empty basenames, this happens for container blobs
+    # (eg "create new folder" in the GCP console)
     return set(
         [
             gs_uri_to_basename(x.name)
             for x in bucket.list_blobs(prefix=f"{root_blob.name}")
+            if gs_uri_to_basename(x.name)
         ]
     )
 

--- a/tests/deepcell_imaging/utils/storage_test.py
+++ b/tests/deepcell_imaging/utils/storage_test.py
@@ -1,4 +1,30 @@
-from deepcell_imaging.utils.storage import find_matching_npz
+from unittest.mock import patch, Mock
+
+from deepcell_imaging.utils.storage import find_matching_npz, get_blob_filenames
+
+
+def test_get_blob_filenames():
+    uri_prefix = "gs://bucket/images/"
+    client = None
+
+    urls = [
+        f"{uri_prefix}/{x}" for x in ["image1.tiff", "image2.tiff", "image3.tiff", ""]
+    ]
+
+    with patch("google.cloud.storage.Blob") as mock_blob:
+        mock_blob.from_string.return_value.bucket.name = "bucket"
+        mock_blob.from_string.return_value.name = "images"
+
+        with patch("google.cloud.storage.Client") as mock_client:
+            mocks = [Mock() for _ in urls]
+            for mock, url in zip(mocks, urls):
+                mock.name = url
+
+            mock_client.return_value.bucket.return_value.list_blobs.return_value = mocks
+
+            result = get_blob_filenames(uri_prefix, client)
+
+    assert result == {"image1", "image2", "image3"}
 
 
 def test_find_matching_npz():


### PR DESCRIPTION
This can happen for blobs that were created as folders, for example if you create the blob gs://some/path/ then it counts as a blob.

Fixes #369 