### PR TITLE
Only load needed compartment data

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -42,10 +42,11 @@ def main():
     with gs_fastcopy.read(raw_predictions_uri) as raw_predictions_file:
         with np.load(raw_predictions_file) as loader:
             # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
-            raw_predictions = {
-                "whole-cell": [loader["arr_0"], loader["arr_1"]],
-                "nuclear": [loader["arr_2"], loader["arr_3"]],
-            }
+            raw_predictions = {}
+            if compartment == "whole-cell" or compartment == "both":
+                raw_predictions["whole-cell"] = [loader["arr_0"], loader["arr_1"]]
+            elif compartment == "nuclear" or compartment == "both":
+                raw_predictions["nuclear"] = [loader["arr_2"], loader["arr_3"]]
 
     raw_predictions_load_time_s = timeit.default_timer() - t
 


### PR DESCRIPTION
This saves memory in single compartment mode: pixels_count * 4bytes * 2    (the 2 prediction channels for the unused compartment)

Fixes #378 