### PR TITLE
Export GeoJSON files

### DIFF
--- a/requirements-mac-arm64.txt
+++ b/requirements-mac-arm64.txt
@@ -10,7 +10,7 @@ smart_open[gcs]
 
 # DeepCell requirements
 deepcell-toolbox>=0.12.1
-deepcell-tracking~=0.6.1
+deepcell-tracking~=0.6.5
 scipy>=1.2.3,<2
 scikit-image>=0.19.3
 # scikit-learn>=0.20.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deepcell==0.12.9
+deepcell==0.12.10
 google-cloud-bigquery
 google-cloud-notebooks
 gs-fastcopy
@@ -8,6 +8,7 @@ numpy
 protobuf==3.20.3
 pydantic
 pytest
+rasterio
 requests
 smart_open[gcs]
 snakeviz

--- a/scripts/predictions-to-geojson.py
+++ b/scripts/predictions-to-geojson.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""
+Script to generate GeoJSON shapes from a segmentation mask.
+
+Reads post-processed predictions from a URI (typically on cloud storage).
+
+Writes a JSON file containing GeoJSON shapes to a URI (typically on cloud storage).
+"""
+
+import json
+import logging
+import timeit
+
+import gs_fastcopy
+import numpy as np
+from rasterio import features
+
+import deepcell_imaging
+from deepcell_imaging import gcp_logging
+from deepcell_imaging.gcp_batch_jobs.types import PredictionsToGeoJsonArgs
+from deepcell_imaging.utils.cmdline import get_task_arguments
+
+
+def main():
+    deepcell_imaging.gcp_logging.initialize_gcp_logging()
+    logger = logging.getLogger(__name__)
+
+    args, env_config = get_task_arguments(
+        "predictions-to-geojson", PredictionsToGeoJsonArgs
+    )
+
+    predictions_uri = args.predictions_uri
+    output_uri = args.output_uri
+
+    logger.info("Loading predictions")
+
+    t = timeit.default_timer()
+
+    with gs_fastcopy.read(predictions_uri) as predictions_file:
+        with np.load(predictions_file) as loader:
+            # An array of shape [height, width, 1] containing intensity of nuclear & membrane channels
+            predictions = np.squeeze(loader["image"])
+
+    logger.info("Loaded predictions in %s s" % round(timeit.default_timer() - t, 2))
+
+    logger.info("Getting prediction shapes")
+
+    t = timeit.default_timer()
+
+    max_int32 = 2**31 - 1
+    if predictions.max() > max_int32:
+        raise ValueError(
+            "Can only handle up to int32=%d unique labels, not %d"
+            % (max_int32, predictions.max())
+        )
+
+    mask = predictions != 0
+    shapes = list(
+        features.shapes(
+            predictions.astype(np.int32, copy=True),
+            mask=mask,
+            connectivity=8,
+        )
+    )
+
+    logger.info("Got prediction shapes in %s s" % round(timeit.default_timer() - t, 2))
+
+    logger.info("Writing GeoJSON shapes to %s" % output_uri)
+
+    t = timeit.default_timer()
+
+    geojson_shapes = [x[0] for x in shapes]
+    with gs_fastcopy.write(output_uri) as output_writer:
+        output_writer.write(json.dumps(geojson_shapes).encode())
+
+    output_json_time_s = timeit.default_timer() - t
+    logger.info("Wrote GeoJSON shapes in %s s" % round(output_json_time_s, 2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -212,6 +212,17 @@ class PostprocessArgs(BaseModel):
     )
 
 
+class PredictionsToGeoJsonArgs(BaseModel):
+    predictions_uri: str = Field(
+        title="Predictions URI",
+        description="URI to post-processed predictions of shape (height, width, 1)",
+    )
+    output_uri: str = Field(
+        title="Output URI",
+        description="URI to write json file containing GeoJSON shapes for detected objects.",
+    )
+
+
 class VisualizeArgs(BaseModel):
     image_uri: str = Field(
         title="Image URI",


### PR DESCRIPTION
This script converts a prediction TIFF file into GeoJSON files. The reason is that ImageJ doesn't support TIFFs with more than ~2B pixels (32bit indexing), so we need an alternate method to detect the segmented regions.

Fixes #386 