### PR TITLE
Output shapes as jsonl

### DIFF
--- a/scripts/predictions-to-geojson.py
+++ b/scripts/predictions-to-geojson.py
@@ -83,7 +83,9 @@ def write_shapes(predictions, output_uri):
     t = timeit.default_timer()
 
     with gs_fastcopy.write(output_uri) as output_writer:
-        output_writer.write(json.dumps(shapes).encode())
+        for shape in shapes:
+            output_writer.write(json.dumps(shape).encode())
+            output_writer.write(b"\n")
 
     output_json_time_s = timeit.default_timer() - t
     logger.info("Wrote %s shapes in %s s", len(shapes), round(output_json_time_s, 2))

--- a/src/deepcell_imaging/gcp_batch_jobs/segment.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/segment.py
@@ -355,11 +355,11 @@ def make_segmentation_tasks(image_names, npz_root, npz_names, masks_output_root)
             f"{masks_output_root}/{image_name}_WholeCellMask.tiff"
         )
         wholecell_geojson_output_uri = (
-            f"{masks_output_root}/{image_name}_WholeCellShapes.json"
+            f"{masks_output_root}/{image_name}_WholeCellShapes.jsonl"
         )
         nuclear_tiff_output_uri = f"{masks_output_root}/{image_name}_NucleusMask.tiff"
         nuclear_geojson_output_uri = (
-            f"{masks_output_root}/{image_name}_NucleusShapes.json"
+            f"{masks_output_root}/{image_name}_NucleusShapes.jsonl"
         )
 
         input_file_contents = list(npz_headers(npz_path))


### PR DESCRIPTION
Fixes #397 

A JSONL file serializes a JSON array with an entry per line, rather than a comma-separated list. This lets applications process the file much more efficiently: handling a line aka entry one at a time vs having to load everything into memory.