### PR TITLE
Add dist-upgrade to OS packages

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -11,7 +11,7 @@ FROM ${BASE_IMAGE}
 # Lastly, install and/or update pip.
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    apt-get update -y && \
+    apt-get update -y && apt-get dist-upgrade -y \
     apt-get install -y --no-install-recommends git google-cloud-sdk google-cloud-cli pigz python3.10 python3-pip python3-dev python3.10-distutils && \
     rm -rf /var/lib/apt/lists/* && \
     python3.10 -m pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
The rebuild on TF2.17 fixed the TF issues, but, we're now using an older 22.04 with OS issues.

<img width="792" alt="Screenshot 2025-01-03 at 12 12 07 PM" src="https://github.com/user-attachments/assets/1ce05b46-c3be-4f92-ac1c-e62221550a1c" />

This PR runs `dist-upgrade` to update OS packages. (We may need to soften to `upgrade` as `dist-upgrade` can be more aggressive)